### PR TITLE
Prefer US spelling for identifier naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1955,6 +1955,18 @@ no parameters.
   salary = 1_000
   ```
 
+* <a name="us-english-identifiers"></a>
+  Prefer US spelling.
+<sup>[[link](#us-english-identifiers)]</sup>
+
+  ```Ruby
+  # good - identifier is in English
+  labour_cost = 1.0
+
+  # better - identifier uses US spelling
+  labor_cost = 1.0
+  ```
+
 * <a name="snake-case-symbols-methods-vars"></a>
   Use `snake_case` for symbols, methods and variables.
 <sup>[[link](#snake-case-symbols-methods-vars)]</sup>


### PR DESCRIPTION
US vs British English spelling of identifiers can lead to mild confusion.  It might be worth setting a preference for a particular spelling.  However, this does feel like it borders on pedantic. What do people think?
