### PR TITLE
Underscores in large numbers

### DIFF
--- a/ruby/.ruby-style.yml
+++ b/ruby/.ruby-style.yml
@@ -513,8 +513,10 @@ Style/NumericLiterals:
   Description: >-
                  Add underscores to large numeric literals to improve their
                  readability.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  StyleGuide: "https://github.com/zestyzesty/zesty-styleguide/tree/master/ruby#underscores-in-numerics"
   Enabled: true
+  MinDigits: 5
+  Strict: false
 
 Style/OneLineConditional:
   Description: >-

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,81 +1,13 @@
-# Prelude
+# Ruby Style Guide
 
-> Role models are important. <br>
-> -- Officer Alex J. Murphy / RoboCop
+## Intro
 
-One thing has always bothered me as a Ruby developer - Python developers have a
-great programming style reference
-([PEP-8][]) and we never got an official
-guide, documenting Ruby coding style and best practices. And I do believe that
-style matters. I also believe that a great hacker community, such as Ruby has,
-should be quite capable of producing this coveted document.
+This style guide was originally forked from the popular [bbatsov Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide)
 
-This guide started its life as our internal company Ruby coding guidelines
-(written by yours truly). At some point I decided that the work I was doing
-might be interesting to members of the Ruby community in general and that the
-world had little need for another internal company guideline. But the world
-could certainly benefit from a community-driven and community-sanctioned set of
-practices, idioms and style prescriptions for Ruby programming.
+## Tools
 
-Since the inception of the guide I've received a lot of feedback from members of
-the exceptional Ruby community around the world. Thanks for all the suggestions
-and the support! Together we can make a resource beneficial to each and every
-Ruby developer out there.
+[RuboCop](https://github.com/bbatsov/rubocop) is a static code analyzer used to detect violations of this style guide. The documentation can be found [here](https://github.com/bbatsov/rubocop)
 
-By the way, if you're into Rails you might want to check out the complementary
-[Ruby on Rails Style Guide][rails-style-guide].
-
-# The Ruby Style Guide
-
-This Ruby style guide recommends best practices so that real-world Ruby
-programmers can write code that can be maintained by other real-world Ruby
-programmers. A style guide that reflects real-world usage gets used, and a style
-guide that holds to an ideal that has been rejected by the people it is supposed
-to help risks not getting used at all &ndash; no matter how good it is.
-
-The guide is separated into several sections of related rules. I've tried to add
-the rationale behind the rules (if it's omitted I've assumed it's pretty
-obvious).
-
-I didn't come up with all the rules out of nowhere - they are mostly
-based on my extensive career as a professional software engineer,
-feedback and suggestions from members of the Ruby community and
-various highly regarded Ruby programming resources, such as
-["Programming Ruby"][pickaxe] and
-["The Ruby Programming Language"][trpl].
-
-There are some areas in which there is no clear consensus in the Ruby community
-regarding a particular style (like string literal quoting, spacing inside hash
-literals, dot position in multi-line method chaining, etc.). In such scenarios
-all popular styles are acknowledged and it's up to you to pick one and apply it
-consistently.
-
-This style guide evolves over time as additional conventions are
-identified and past conventions are rendered obsolete by changes in
-Ruby itself.
-
-Many projects have their own coding style guidelines (often derived
-from this guide). In the event of any conflicts, such
-project-specific guides take precedence for that project.
-
-You can generate a PDF or an HTML copy of this guide using
-[Transmuter][].
-
-[RuboCop][] is a code analyzer, based on this
-style guide.
-
-Translations of the guide are available in the following languages:
-
-* [Chinese Simplified](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhCN.md)
-* [Chinese Traditional](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhTW.md)
-* [French](https://github.com/gauthier-delacroix/ruby-style-guide/blob/master/README-frFR.md)
-* [German](https://github.com/arbox/de-ruby-style-guide/blob/master/README-deDE.md)
-* [Japanese](https://github.com/fortissimo1997/ruby-style-guide/blob/japanese/README.ja.md)
-* [Korean](https://github.com/dalzony/ruby-style-guide/blob/master/README-koKR.md)
-* [Portuguese](https://github.com/rubensmabueno/ruby-style-guide/blob/master/README-PT-BR.md)
-* [Russian](https://github.com/arbox/ruby-style-guide/blob/master/README-ruRU.md)
-* [Spanish](https://github.com/alemohamad/ruby-style-guide/blob/master/README-esLA.md)
-* [Vietnamese](https://github.com/scrum2b/ruby-style-guide/blob/master/README-viVN.md)
 
 ## Table of Contents
 
@@ -173,7 +105,7 @@ Translations of the guide are available in the following languages:
 * <a name="no-single-line-methods"></a>
   Avoid single-line methods. Although they are somewhat popular in the wild,
   there are a few peculiarities about their definition syntax that make their
-  use undesirable. The only exception is for single expression methods, 
+  use undesirable. The only exception is for single expression methods,
   but even those may be scrutinized in the wild.
 
   Be sure that it's not possible to use `delegate` or `alias` before opting for
@@ -188,7 +120,7 @@ Translations of the guide are available in the following languages:
   def some_method
     body
   end
-  
+
   # okay-ish
   def whatever; false; end
   ```
@@ -233,7 +165,7 @@ Translations of the guide are available in the following languages:
 
   # bad - no space after { and before }
   {one: 1, two: 2}
-  
+
   Interpolation:
   # good - no space after { and before }
   "#{user.name}"
@@ -531,6 +463,8 @@ Translations of the guide are available in the following languages:
 
 * <a name="underscores-in-numerics"></a>
   Add underscores to large numeric literals to improve their readability.
+  When dealing with normal numbers, separate in threes. When dealing with money/cents,
+  separate the final two digits with an underscore, and then separate in threes as normal.
 <sup>[[link](#underscores-in-numerics)]</sup>
 
   ```Ruby
@@ -539,6 +473,10 @@ Translations of the guide are available in the following languages:
 
   # good - much easier to parse for the human brain
   num = 1_000_000
+
+  # good - representing a monetary value in cents
+  num = 25_99 # $25.99
+  num = 1_000_00 # 1,000.00
   ```
 
 * <a name="rdoc-conventions"></a>


### PR DESCRIPTION
This is already in our styleguide, however the recent config changes have resulted in rubocop now barking about it. I've expanded the example to include money, which the [cop does support](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/numeric_literals.rb) using the `Strict` flag.