### PR TITLE
Ignore Block Length in Rake Tasks

### DIFF
--- a/ruby/.ruby-style.yml
+++ b/ruby/.ruby-style.yml
@@ -911,6 +911,7 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
     - "apps/*/spec/**/*"
+    - "lib/tasks/*"
 
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'


### PR DESCRIPTION
Many of our rake tasks violate this, however by nature of how name-spacing these works, it's pretty unavoidable. Therefore, I propose to exclude our tasks directory from this check, so as to avoid this:

<img width="732" alt="screenshot 2017-06-27 11 20 36" src="https://user-images.githubusercontent.com/2105326/27603358-bd68d374-5b2a-11e7-8eac-87d5dedf91f1.png">
