### PR TITLE
Change percent literal delimiters to fit our guide

### DIFF
--- a/ruby/.ruby-style.yml
+++ b/ruby/.ruby-style.yml
@@ -556,6 +556,17 @@ Style/PercentLiteralDelimiters:
   Description: 'Use `%`-literal delimiters consistently'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
   Enabled: true
+  PreferredDelimiters:
+   '%':  ()
+   '%i': ()
+   '%I': ()
+   '%q': ()
+   '%Q': ()
+   '%r': '{}'
+   '%s': ()
+   '%w': ()
+   '%W': ()
+   '%x': ()
 
 Style/PercentQLiterals:
   Description: 'Checks if uses of %Q/%q match the configured preference.'


### PR DESCRIPTION
>> Prefer () as delimiters for all % literals, except %r. Since parentheses often appear inside regular expressions in many scenarios a less common character like { might be a better choice for a delimiter, depending on the regexp's content.