### PR TITLE
use  array indentation enforcement

### DIFF
--- a/ruby/.ruby-style.yml
+++ b/ruby/.ruby-style.yml
@@ -384,6 +384,7 @@ Layout/IndentArray:
                  Checks the indentation of the first element in an array
                  literal.
   Enabled: true
+  EnforcedStyle: consistent
 
 Layout/IndentAssignment:
   Description: >-


### PR DESCRIPTION
See options: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentArray

I am of the opinion that this should not be copped:

![screen shot 2018-08-29 at 11 37 12 am](https://user-images.githubusercontent.com/12285859/44808011-e8d0e280-ab7f-11e8-9103-f8a6f1677187.png)

Looks like we [already do this for `Hash`](https://github.com/zestyzesty/zesty-styleguide/blob/2ddd55bc6f5161aaeea2e2dbbd8e4d2a56354619/ruby/.ruby-style.yml#L397)
