### PR TITLE
exclude specs from line-length cop

### DIFF
--- a/ruby/.ruby-style.yml
+++ b/ruby/.ruby-style.yml
@@ -972,6 +972,10 @@ Metrics/LineLength:
   Description: 'Limit lines to 100 characters.'
   Max: 100
   Enabled: true
+  Exclude:
+    - "spec/**/*"
+    - "apps/*/spec/**/*"
+
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'


### PR DESCRIPTION
Having to break lines for verbose descriptions, or having to use a less descriptive `it` statement feel worse than allowing lines to run free.

Thoughts?