### PR TITLE
⏫🐷 bump rubocop to 0.75.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,6 @@
+rubocop:
+  version: 0.75.0
+
 ruby:
   enabled: true
   config_file: ruby/.ruby-style.yml


### PR DESCRIPTION
The default is 0.54.0; we have our styleguide conforming to 0.75.0.

http://help.houndci.com/en/articles/2137566-rubocop
http://help.houndci.com/en/articles/2489940-linter-versioning