### PR TITLE
Add a `styles.yml` file for Rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,4 @@ require:
 inherit_from:
   - 'ruby/.ruby-style.yml'
   - 'rails/.rails-style.yml'
+  - 'rspec/.rspec-style.yml'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 * [Rails](./rails)
 
+* [RSpec](./rspec)
+
 A note on the language:
 
 * "Avoid" means don't do it unless you have good reason.

--- a/rspec/.rspec-style.yml
+++ b/rspec/.rspec-style.yml
@@ -1,0 +1,3 @@
+RSpec/ExampleLength:
+  StyleGuide: 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength'
+  Enabled: false

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -1,0 +1,3 @@
+# RSpec Style Guide
+
+See https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/


### PR DESCRIPTION
This PR adds a styles file for overriding the default RSpec cops.

- Disables the `RSpec/ExampleLength` Cop