### PR TITLE
📂 use relative filepath in inheritance config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,5 +3,5 @@ require:
   - rubocop-rails
   - rubocop-rspec
 inherit_from:
-  - 'ruby/.ruby-style.yml'
-  - 'rails/.rails-style.yml'
+  - './ruby/.ruby-style.yml'
+  - './rails/.rails-style.yml'


### PR DESCRIPTION
Locally, rubocop is having trouble loading the config from github. It can't find a path at ruby/rails/.rails-style, which makes sense because the path isa t rails/.rails-style.  I am hoping that making the path relativity explicit can help the gem resolve where to look for its config.